### PR TITLE
ssd 및 관련 테스트에 대해 클린 코드 작업 진행함.

### DIFF
--- a/ssd/__main__.py
+++ b/ssd/__main__.py
@@ -1,9 +1,7 @@
 import sys
 
 from ssd.solidstatedrive import SolidStateDrive
-
-LBA_LOWER_LIMIT = 0
-LBA_UPPER_LIMIT = 99
+from ssd.common import LBA_LOWER_LIMIT, LBA_UPPER_LIMIT
 
 
 class SSDRunner:
@@ -19,7 +17,7 @@ class SSDRunner:
             raise ValueError('R 또는 W를 사용해주세요.(대문자)')
 
         if not LBA_LOWER_LIMIT <= int(sys.argv[2]) <= LBA_UPPER_LIMIT:
-            raise ValueError('LBA는 0 ~ 99 여야합니다.')
+            raise ValueError(f'LBA는 {LBA_LOWER_LIMIT} ~ {LBA_UPPER_LIMIT} 여야합니다.')
 
         if sys.argv[1] == 'W':
             if len(sys.argv) < 4:

--- a/ssd/common.py
+++ b/ssd/common.py
@@ -1,2 +1,9 @@
+from typing import Final
+
+LBA_LOWER_LIMIT: Final[int] = 0
+LBA_UPPER_LIMIT: Final[int] = 99
+LBA_SIZE: Final[int] = LBA_UPPER_LIMIT - LBA_LOWER_LIMIT + 1
+
+
 def convert_hex_to_str(value):
     return f"0x{value:08X}"

--- a/ssd/nand_driver.py
+++ b/ssd/nand_driver.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import Union
 

--- a/ssd/result_manager.py
+++ b/ssd/result_manager.py
@@ -6,8 +6,15 @@ RESULT_FILE_PATH = Path(__file__).parent / 'result.txt'
 class ResultManager:
 
     def __init__(self):
-        self.result_file_path = RESULT_FILE_PATH
+        self.result_file_path: Path = RESULT_FILE_PATH
+        self.initialize()
+
+    def initialize(self):
+        # 만일 result.txt 파일이 없으면, 초기화 된 파일 생성
+        if not self.result_file_path.exists():
+            with open(self.result_file_path, 'w', encoding='utf-8') as f:
+                f.write("0x00000000")
 
     def write(self, text):
-        with open(self.result_file_path, 'w') as f:
+        with open(self.result_file_path, 'w', encoding='utf-8') as f:
             f.write(text)

--- a/tests/ssd_test/test_main.py
+++ b/tests/ssd_test/test_main.py
@@ -5,7 +5,6 @@ import sys
 from unittest import TestCase
 
 from ssd.__main__ import SSDRunner
-from ssd.nand_driver import NandDriver
 from ssd.result_manager import RESULT_FILE_PATH
 
 

--- a/tests/ssd_test/test_main.py
+++ b/tests/ssd_test/test_main.py
@@ -5,14 +5,13 @@ import sys
 from unittest import TestCase
 
 from ssd.__main__ import SSDRunner
-from ssd.nand_driver import NandDriver, NAND_FILE_PATH
+from ssd.nand_driver import NandDriver
 from ssd.result_manager import RESULT_FILE_PATH
 
 
 class TestSSDRunner(TestCase):
     def setUp(self):
         self.runner = SSDRunner()
-        NandDriver.initiate_nand_file(NAND_FILE_PATH)
 
     def test_run_ssd_write_and_read(self):
         params = [

--- a/tests/ssd_test/test_nand_driver.py
+++ b/tests/ssd_test/test_nand_driver.py
@@ -12,19 +12,13 @@ class TestNandDriver(TestCase):
     @patch("builtins.open", new_callable=mock_open,
            read_data='0x00000000\n0x00000000\n0x00000000\n0x1298CDEF\n0x00000000')
     def test_read(self, _):
-        self.assertEqual(0x1298CDEF, self.driver.read(3))
+        ret = self.driver.read(3)
+        self.assertEqual(0x1298CDEF, ret)
+        builtins.open.assert_called_once()
 
     @patch("builtins.open")
     def test_write(self, _):
         self.driver.write(3, 0x1298CDEF)
 
         self.assertEqual(builtins.open.call_count, 2)
-        builtins.open.assert_called_with(self.driver.nand_file_path, 'w')
-
-    def test_write_value(self):
-        fake_nand = '0x00000000\n0x00000000\n0x00000000'
-        expected = '0x00000000\n0x1298CDEF\n0x00000000'
-
-        actual = self.driver.write_value(fake_nand, 1, 0x1298CDEF)
-
-        self.assertEqual(expected, actual)
+        builtins.open.assert_called_with(self.driver.nand_file_path, 'w', encoding='utf-8')

--- a/tests/ssd_test/test_nand_driver.py
+++ b/tests/ssd_test/test_nand_driver.py
@@ -22,3 +22,15 @@ class TestNandDriver(TestCase):
 
         self.assertEqual(builtins.open.call_count, 2)
         builtins.open.assert_called_with(self.driver.nand_file_path, 'w', encoding='utf-8')
+
+    def test_write_value(self):
+        # 전체 데이터에서 지정 된 LBA 의 값만 변경하는지 확인하는 테스트
+        fake_data = '0x00000000\n0x00000000\n0x00000000'
+        expected_data = ['0x00000000\n', '0x1298CDEF\n', '0x00000000']
+        with patch('builtins.open',
+                   mock_open(read_data=fake_data)) as mocked_open:
+            self.driver.write(1, 0x1298CDEF)
+            mocked_open.assert_called_with(self.driver.nand_file_path, 'w', encoding='utf-8')
+
+            handle = mocked_open()
+            handle.writelines.assert_called_once_with(expected_data)

--- a/tests/ssd_test/test_ssd.py
+++ b/tests/ssd_test/test_ssd.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from unittest.mock import Mock, patch
 
 from ssd.nand_driver import NandDriver
+from ssd.result_manager import ResultManager
 from ssd.solidstatedrive import SolidStateDrive
 
 
@@ -11,7 +12,7 @@ class TestSSD(TestCase):
         self.ssd = SolidStateDrive()
 
     def test_write(self):
-        self.ssd.nand_driver = Mock()
+        self.ssd.nand_driver = Mock(spec=NandDriver)
 
         self.ssd.write(3, 0x1298CDEF)
 
@@ -19,9 +20,8 @@ class TestSSD(TestCase):
 
     @patch.object(NandDriver, 'read', return_value=0xAAAABBBB)
     def test_read(self, _):
-        self.ssd.result_manager = Mock()
-        lba = 2
-        expected = '0xAAAABBBB'
+        self.ssd.result_manager = Mock(spec=ResultManager)
+        lba, expected = 2, '0xAAAABBBB'
 
         self.ssd.read(lba)
 


### PR DESCRIPTION
### 작업 내용

- 상수는 `common.py` 로 옮겨 한 곳에서 관리
- LBA_COUNT 는 LBA_SIZE로 이름 변경하고 `UPPER_LIMIT - LOWER_LIMIT + 1`  로 사용하도록 변경
- 상수들에 대해서는 `typing.Final` 타입 힌트 적용
- `NandDriver` 클래스의 `write_value` 메서드 삭제하고 `write` 메서드에 병합. lines 를 list로 관리하면 5줄의 코드로도 write 기능 구현 가능. 
- `ResultManager` 도 `NandDriver` 처럼 초기화 시 초기화 된 `result.txt` 파일 생성하도록 변경
- `test_ssd.py` 파일에서 Mock() 마다 spec 지정.  