### PR TITLE
[mod] TestShell 클래스의 일부 역할을 CommandParser 클래스로 이관

### DIFF
--- a/testapp/command_parser.py
+++ b/testapp/command_parser.py
@@ -104,3 +104,7 @@ class CommandParser:
                 cmd_args[0] = int(cmd_args[0], 16)
             return cmd_option, cmd_args
         return cmd_option, None
+
+    @classmethod
+    def get_command(cls, cmd_option):
+        return cls.cmd_if_dict[cmd_option]()

--- a/testapp/command_parser.py
+++ b/testapp/command_parser.py
@@ -29,44 +29,29 @@ def is_valid_hex(s: str):
 
 class CommandParser:
     cmd_if_dict = {
-        "write": command.Write,
-        "read": command.Read,
-        "exit": command.Exit,
-        "help": command.Help,
-        "fullwrite": command.FullWrite,  # noqa
-        "fullread": command.FullRead,  # noqa
-        "testapp1": TestApp1,
-        "testapp2": TestApp2,
+        "write": {"class": command.Write, "required_args_cnt": 2},
+        "read": {"class": command.Read, "required_args_cnt": 1},
+        "exit": {"class": command.Exit, "required_args_cnt": 0},
+        "help": {"class": command.Help, "required_args_cnt": 0},
+        "fullwrite": {"class": command.FullWrite, "required_args_cnt": 1},  # noqa
+        "fullread": {"class": command.FullRead, "required_args_cnt": 0},  # noqa
+        "testapp1": {"class": TestApp1, "required_args_cnt": 0},
+        "testapp2": {"class": TestApp2, "required_args_cnt": 0},
     }
 
-    @staticmethod
-    def validate_command(cmd) -> bool:
-        """
-        유효성 검사 수행
-        """
-        cmd_option_to_args_dict = {
-            "write": 2,
-            "read": 1,
-            "help": 0,
-            "fullwrite": 1,
-            "fullread": 0,
-            "testapp1": 0,
-            "testapp2": 0,
-            "exit": 0,
-        }
+    @classmethod
+    def validate_command(cls, cmd) -> bool:
         cmd_list = cmd.split(" ")
         cmd_option = cmd_list[0]
         n_args = len(cmd_list) - 1
-        if cmd_option not in cmd_option_to_args_dict.keys():
+        if cmd_option not in cls.cmd_if_dict.keys():
             print("Command does not exist")
             return False
-        if cmd_option_to_args_dict[cmd_option] != n_args:
+
+        if cls.cmd_if_dict[cmd_option]['required_args_cnt'] != n_args:
             print("The number of argument does not match")
             return False
-        # 0. exit (구현 필요 x), help, fullread , testapp1, testapp2
-        if n_args == 0:
-            return True
-        # 1. write
+
         if cmd_option == "write":
             n_lba = cmd_list[1]
             value = cmd_list[2]
@@ -75,18 +60,14 @@ class CommandParser:
             if not is_valid_hex(value):
                 return False
             return True
-        # 2. read
+
         if cmd_option == "read":
             n_lba = cmd_list[1]
             return True if is_in_range_lba(n_lba) else False
 
-        # 3. fullwrite
         if cmd_option == "fullwrite":
             value = cmd_list[1]
-            if is_valid_hex(value):
-                return True
-            else:
-                return False
+            return True if is_valid_hex(value) else False
         return True
 
     @staticmethod
@@ -107,4 +88,4 @@ class CommandParser:
 
     @classmethod
     def get_command(cls, cmd_option):
-        return cls.cmd_if_dict[cmd_option]()
+        return cls.cmd_if_dict[cmd_option]["class"]()

--- a/testapp/command_parser.py
+++ b/testapp/command_parser.py
@@ -1,0 +1,106 @@
+import re
+from typing import Tuple, Optional, List
+
+from testapp import command
+from testapp.constants import SSD_START_LBA, SSD_END_LBA, SSD_MIN_VALUE, SSD_MAX_VALUE
+from testapp.test_app1 import TestApp1
+from testapp.test_app2 import TestApp2
+
+
+def is_in_range_lba(lba: str) -> bool:
+    try:
+        num = int(lba)
+        return SSD_START_LBA <= num <= SSD_END_LBA
+    except ValueError:
+        return False
+
+
+def is_valid_hex(s: str):
+    # 정규식으로 형식을 먼저 확인
+    if re.fullmatch(r"0x[0-9A-Fa-f]{8}", s):
+        try:
+            # 16진수로 변환하여 범위를 확인
+            num = int(s, 16)
+            return SSD_MIN_VALUE <= num <= SSD_MAX_VALUE
+        except ValueError:
+            return False
+    return False
+
+
+class CommandParser:
+    cmd_if_dict = {
+        "write": command.Write,
+        "read": command.Read,
+        "exit": command.Exit,
+        "help": command.Help,
+        "fullwrite": command.FullWrite,  # noqa
+        "fullread": command.FullRead,  # noqa
+        "testapp1": TestApp1,
+        "testapp2": TestApp2,
+    }
+
+    @staticmethod
+    def validate_command(cmd) -> bool:
+        """
+        유효성 검사 수행
+        """
+        cmd_option_to_args_dict = {
+            "write": 2,
+            "read": 1,
+            "help": 0,
+            "fullwrite": 1,
+            "fullread": 0,
+            "testapp1": 0,
+            "testapp2": 0,
+            "exit": 0,
+        }
+        cmd_list = cmd.split(" ")
+        cmd_option = cmd_list[0]
+        n_args = len(cmd_list) - 1
+        if cmd_option not in cmd_option_to_args_dict.keys():
+            print("Command does not exist")
+            return False
+        if cmd_option_to_args_dict[cmd_option] != n_args:
+            print("The number of argument does not match")
+            return False
+        # 0. exit (구현 필요 x), help, fullread , testapp1, testapp2
+        if n_args == 0:
+            return True
+        # 1. write
+        if cmd_option == "write":
+            n_lba = cmd_list[1]
+            value = cmd_list[2]
+            if not is_in_range_lba(n_lba):
+                return False
+            if not is_valid_hex(value):
+                return False
+            return True
+        # 2. read
+        if cmd_option == "read":
+            n_lba = cmd_list[1]
+            return True if is_in_range_lba(n_lba) else False
+
+        # 3. fullwrite
+        if cmd_option == "fullwrite":
+            value = cmd_list[1]
+            if is_valid_hex(value):
+                return True
+            else:
+                return False
+        return True
+
+    @staticmethod
+    def parse_args(cmd: str) -> Tuple[str, Optional[List[int]]]:
+        cmd_list = cmd.split(" ")
+        cmd_option = cmd_list[0]
+        if len(cmd_list) > 1:
+            cmd_args: list = cmd_list[1:]
+            if cmd_option == "read":
+                cmd_args[0] = int(cmd_args[0])
+            elif cmd_option == "write":
+                cmd_args[0] = int(cmd_args[0])
+                cmd_args[1] = int(cmd_args[1], 16)
+            elif cmd_option == "fullwrite":
+                cmd_args[0] = int(cmd_args[0], 16)
+            return cmd_option, cmd_args
+        return cmd_option, None

--- a/testapp/testshell.py
+++ b/testapp/testshell.py
@@ -16,7 +16,7 @@ class TestShell:
 
         cmd_option, cmd_args = CommandParser.parse_args(cmd)
 
-        cmd_if = CommandParser.cmd_if_dict[cmd_option]()
+        cmd_if = CommandParser.get_command(cmd_option)
         if cmd_args is not None:
             print(cmd_option, *cmd_args)
             cmd_if.run(*cmd_args)

--- a/testapp/testshell.py
+++ b/testapp/testshell.py
@@ -1,58 +1,21 @@
-import re
-from typing import Tuple, Optional, List
-
-from testapp import command
-from testapp.test_app1 import TestApp1
-from testapp.test_app2 import TestApp2
-from testapp.constants import (SSD_MIN_VALUE, SSD_MAX_VALUE,
-                               SSD_START_LBA, SSD_END_LBA, INVALID_COMMAND)
-
+from testapp.command_parser import CommandParser
+from testapp.constants import (INVALID_COMMAND)
 
 EXECUTE_VALID_WO_ARGS = 2
 EXECUTE_VALID_WITH_ARGS = 1
 EXECUTE_INVALID = 0
 
 
-def is_in_range_lba(lba: str) -> bool:
-    try:
-        num = int(lba)
-        return SSD_START_LBA <= num <= SSD_END_LBA
-    except ValueError:
-        return False
-
-
-def is_valid_hex(s: str):
-    # 정규식으로 형식을 먼저 확인
-    if re.fullmatch(r"0x[0-9A-Fa-f]{8}", s):
-        try:
-            # 16진수로 변환하여 범위를 확인
-            num = int(s, 16)
-            return SSD_MIN_VALUE <= num <= SSD_MAX_VALUE
-        except ValueError:
-            return False
-    return False
-
-
 class TestShell:
-    cmd_if_dict = {
-        "write": command.Write,
-        "read": command.Read,
-        "exit": command.Exit,
-        "help": command.Help,
-        "fullwrite": command.FullWrite,  # noqa
-        "fullread": command.FullRead,  # noqa
-        "testapp1": TestApp1,
-        "testapp2": TestApp2,
-    }
 
     def execute(self, cmd: str) -> int:
-        if not self.validate_command(cmd):
+        if not CommandParser.validate_command(cmd):
             print(INVALID_COMMAND)
             return EXECUTE_INVALID
 
-        cmd_option, cmd_args = self.parse_args(cmd)
+        cmd_option, cmd_args = CommandParser.parse_args(cmd)
 
-        cmd_if = self.cmd_if_dict[cmd_option]()
+        cmd_if = CommandParser.cmd_if_dict[cmd_option]()
         if cmd_args is not None:
             print(cmd_option, *cmd_args)
             cmd_if.run(*cmd_args)
@@ -62,79 +25,9 @@ class TestShell:
         cmd_if.run()
         return EXECUTE_VALID_WO_ARGS
 
-    @staticmethod
-    def validate_command(cmd) -> bool:
-        """
-        유효성 검사 수행
-        """
-        cmd_option_to_args_dict = {
-            "write": 2,
-            "read": 1,
-            "help": 0,
-            "fullwrite": 1,
-            "fullread": 0,
-            "testapp1": 0,
-            "testapp2": 0,
-            "exit": 0,
-        }
-        cmd_list = cmd.split(" ")
-        cmd_option = cmd_list[0]
-        n_args = len(cmd_list) - 1
-        if cmd_option not in cmd_option_to_args_dict.keys():
-            print("Command does not exist")
-            return False
-        if cmd_option_to_args_dict[cmd_option] != n_args:
-            print("The number of argument does not match")
-            return False
-        # 0. exit (구현 필요 x), help, fullread , testapp1, testapp2
-        if n_args == 0:
-            return True
-        # 1. write
-        if cmd_option == "write":
-            n_lba = cmd_list[1]
-            value = cmd_list[2]
-            if not is_in_range_lba(n_lba):
-                return False
-            if not is_valid_hex(value):
-                return False
-            return True
-        # 2. read
-        if cmd_option == "read":
-            n_lba = cmd_list[1]
-            return True if is_in_range_lba(n_lba) else False
-
-        # 3. fullwrite
-        if cmd_option == "fullwrite":
-            value = cmd_list[1]
-            if is_valid_hex(value):
-                return True
-            else:
-                return False
-        return True
-
-    @staticmethod
-    def parse_args(cmd: str) -> Tuple[str, Optional[List[int]]]:
-        cmd_list = cmd.split(" ")
-        cmd_option = cmd_list[0]
-        if len(cmd_list) > 1:
-            cmd_args: list = cmd_list[1:]
-            if cmd_option == "read":
-                cmd_args[0] = int(cmd_args[0])
-            elif cmd_option == "write":
-                cmd_args[0] = int(cmd_args[0])
-                cmd_args[1] = int(cmd_args[1], 16)
-            elif cmd_option == "fullwrite":
-                cmd_args[0] = int(cmd_args[0], 16)
-            return cmd_option, cmd_args
-        return cmd_option, None
-
 
 def main():
     ts = TestShell()
     while True:
         cmd = input("> ")
         ts.execute(cmd)
-
-
-if __name__ == "__main__":
-    main()

--- a/testapp/testshell.py
+++ b/testapp/testshell.py
@@ -1,5 +1,5 @@
 from testapp.command_parser import CommandParser
-from testapp.constants import (INVALID_COMMAND)
+from testapp.constants import INVALID_COMMAND
 
 EXECUTE_VALID_WO_ARGS = 2
 EXECUTE_VALID_WITH_ARGS = 1
@@ -8,7 +8,8 @@ EXECUTE_INVALID = 0
 
 class TestShell:
 
-    def execute(self, cmd: str) -> int:
+    @staticmethod
+    def execute(cmd: str) -> int:
         if not CommandParser.validate_command(cmd):
             print(INVALID_COMMAND)
             return EXECUTE_INVALID
@@ -27,7 +28,6 @@ class TestShell:
 
 
 def main():
-    ts = TestShell()
     while True:
         cmd = input("> ")
-        ts.execute(cmd)
+        TestShell.execute(cmd)

--- a/tests/testapp_test/test_command_parser.py
+++ b/tests/testapp_test/test_command_parser.py
@@ -1,0 +1,120 @@
+from unittest import TestCase
+
+from testapp.command_parser import CommandParser
+
+
+class TestCommandParser(TestCase):
+
+    def setUp(self):
+        self.parser = CommandParser()
+
+    def test_valid_cmd_true(self):
+        cmd_list = [
+            "write 3 0xAAAABBBB",
+            "read 3",
+            "help",
+            "fullwrite 0xABCDFFFF",
+            "fullread",
+            "testapp1",
+            "testapp2",
+        ]
+        for idx, cmd in enumerate(cmd_list):
+            with self.subTest(idx=idx, cmd=cmd):
+                print(f"{idx + 1}. {cmd}")
+                ret = self.parser.validate_command(cmd)
+                self.assertTrue(ret)
+
+    def test_valid_cmd_write_false(self):
+
+        cmd_list = [
+            "Write 3 0xAAAABBBB",
+            "Write 3 0xAAAABBBB",
+            "write 0xAAAABBBB",
+            "write 3",
+            "write",
+        ]
+        for idx, cmd in enumerate(cmd_list):
+            with self.subTest(idx=idx, cmd=cmd):
+                print(f"{idx + 1}. {cmd}")
+                ret = self.parser.validate_command(cmd)
+                self.assertFalse(ret)
+
+    def test_valid_cmd_read_false(self):
+
+        cmd_list = [
+            "read 3 0xAAAABBBB",
+            "Read 3",
+            "read 0xAAAABBBB",
+        ]
+        for idx, cmd in enumerate(cmd_list):
+            with self.subTest(idx=idx, cmd=cmd):
+                print(f"{idx + 1}. {cmd}")
+                ret = self.parser.validate_command(cmd)
+                self.assertFalse(ret)
+
+    def test_valid_cmd_exit_false(self):
+
+        cmd_list = [
+            "Exit",
+            "exit 1",
+            "exit 0xABCDFFFF",
+        ]
+        for idx, cmd in enumerate(cmd_list):
+            with self.subTest(idx=idx, cmd=cmd):
+                print(f"{idx + 1}. {cmd}")
+                ret = self.parser.validate_command(cmd)
+                self.assertFalse(ret)
+
+    def test_valid_cmd_help_false(self):
+
+        cmd_list = [
+            "HELP",
+            "hELP",
+            "help 0xABCDFFFF",
+        ]
+        for idx, cmd in enumerate(cmd_list):
+            with self.subTest(idx=idx, cmd=cmd):
+                print(f"{idx + 1}. {cmd}")
+                ret = self.parser.validate_command(cmd)
+                self.assertFalse(ret)
+
+    def test_valid_cmd_fullwrite_false(self):
+
+        cmd_list = [
+            "Fullwrite 0xABCDFFFF",
+            "FULLWRITE 0xABCDFFFF",
+            "FullWrite 0xABCDFFFF",
+            "fullwrite ABCDFFFF",
+        ]
+        for idx, cmd in enumerate(cmd_list):
+            with self.subTest(idx=idx, cmd=cmd):
+                print(f"{idx + 1}. {cmd}")
+                ret = self.parser.validate_command(cmd)
+                self.assertFalse(ret)
+
+    def test_valid_cmd_fullread_false(self):
+
+        cmd_list = [
+            "Fullread",
+            "FULLREAD",
+            "FullRead",
+        ]
+        for idx, cmd in enumerate(cmd_list):
+            with self.subTest(idx=idx, cmd=cmd):
+                print(f"{idx + 1}. {cmd}")
+                ret = self.parser.validate_command(cmd)
+                self.assertFalse(ret)
+
+    def test_parse_args(self):
+        cmd_dict = {
+            "write 3 0xAAAABBBB": ("write", [3, 0xAAAABBBB]),
+            "read 3": ("read", [3]),
+            "help": ("help", None),
+            "fullwrite 0xABCDFFFF": ("fullwrite", [0xABCDFFFF]),
+            "fullread": ("fullread", None),
+        }
+        for idx, (key, val) in enumerate(cmd_dict.items()):
+            with self.subTest(idx=idx, key=key, val=val):
+                print(f"{idx + 1}. {key},{val}")
+                ret = self.parser.parse_args(key)
+                self.assertEqual(ret, val)

--- a/tests/testapp_test/test_testshell.py
+++ b/tests/testapp_test/test_testshell.py
@@ -1,10 +1,10 @@
 from unittest import TestCase
 from unittest.mock import patch
 
+from testapp.command import Read, Write, FullRead, FullWrite
 from testapp.test_app1 import TestApp1
 from testapp.test_app2 import TestApp2
 from testapp.testshell import TestShell, EXECUTE_INVALID, EXECUTE_VALID_WO_ARGS, EXECUTE_VALID_WITH_ARGS
-from testapp.command import Read, Write, FullRead, FullWrite
 
 
 class TestTestShell(TestCase):
@@ -18,117 +18,6 @@ class TestTestShell(TestCase):
         self.ts = TestShell()
         TestTestShell.test_counter += 1
         print(f"\nRunning test #{TestTestShell.test_counter}")
-
-    def test_valid_cmd_true(self):
-        cmd_list = [
-            "write 3 0xAAAABBBB",
-            "read 3",
-            "help",
-            "fullwrite 0xABCDFFFF",
-            "fullread",
-            "testapp1",
-            "testapp2",
-        ]
-        for idx, cmd in enumerate(cmd_list):
-            with self.subTest(idx=idx, cmd=cmd):
-                print(f"{idx + 1}. {cmd}")
-                ret = self.ts.validate_command(cmd)
-                self.assertTrue(ret)
-
-    def test_valid_cmd_write_false(self):
-
-        cmd_list = [
-            "Write 3 0xAAAABBBB",
-            "Write 3 0xAAAABBBB",
-            "write 0xAAAABBBB",
-            "write 3",
-            "write",
-        ]
-        for idx, cmd in enumerate(cmd_list):
-            with self.subTest(idx=idx, cmd=cmd):
-                print(f"{idx + 1}. {cmd}")
-                ret = self.ts.validate_command(cmd)
-                self.assertFalse(ret)
-
-    def test_valid_cmd_read_false(self):
-
-        cmd_list = [
-            "read 3 0xAAAABBBB",
-            "Read 3",
-            "read 0xAAAABBBB",
-        ]
-        for idx, cmd in enumerate(cmd_list):
-            with self.subTest(idx=idx, cmd=cmd):
-                print(f"{idx + 1}. {cmd}")
-                ret = self.ts.validate_command(cmd)
-                self.assertFalse(ret)
-
-    def test_valid_cmd_exit_false(self):
-
-        cmd_list = [
-            "Exit",
-            "exit 1",
-            "exit 0xABCDFFFF",
-        ]
-        for idx, cmd in enumerate(cmd_list):
-            with self.subTest(idx=idx, cmd=cmd):
-                print(f"{idx + 1}. {cmd}")
-                ret = self.ts.validate_command(cmd)
-                self.assertFalse(ret)
-
-    def test_valid_cmd_help_false(self):
-
-        cmd_list = [
-            "HELP",
-            "hELP",
-            "help 0xABCDFFFF",
-        ]
-        for idx, cmd in enumerate(cmd_list):
-            with self.subTest(idx=idx, cmd=cmd):
-                print(f"{idx + 1}. {cmd}")
-                ret = self.ts.validate_command(cmd)
-                self.assertFalse(ret)
-
-    def test_valid_cmd_fullwrite_false(self):
-
-        cmd_list = [
-            "Fullwrite 0xABCDFFFF",
-            "FULLWRITE 0xABCDFFFF",
-            "FullWrite 0xABCDFFFF",
-            "fullwrite ABCDFFFF",
-        ]
-        for idx, cmd in enumerate(cmd_list):
-            with self.subTest(idx=idx, cmd=cmd):
-                print(f"{idx + 1}. {cmd}")
-                ret = self.ts.validate_command(cmd)
-                self.assertFalse(ret)
-
-    def test_valid_cmd_fullread_false(self):
-
-        cmd_list = [
-            "Fullread",
-            "FULLREAD",
-            "FullRead",
-        ]
-        for idx, cmd in enumerate(cmd_list):
-            with self.subTest(idx=idx, cmd=cmd):
-                print(f"{idx + 1}. {cmd}")
-                ret = self.ts.validate_command(cmd)
-                self.assertFalse(ret)
-
-    def test_parse_args(self):
-        cmd_dict = {
-            "write 3 0xAAAABBBB": ("write", [3, 0xAAAABBBB]),
-            "read 3": ("read", [3]),
-            "help": ("help", None),
-            "fullwrite 0xABCDFFFF": ("fullwrite", [0xABCDFFFF]),
-            "fullread": ("fullread", None),
-        }
-        for idx, (key, val) in enumerate(cmd_dict.items()):
-            with self.subTest(idx=idx, key=key, val=val):
-                print(f"{idx + 1}. {key},{val}")
-                ret = self.ts.parse_args(key)
-                self.assertEqual(ret, val)
 
     @patch.object(TestApp2, "run", return_value=True)
     @patch.object(TestApp1, "run", return_value=True)


### PR DESCRIPTION
* TestShell 클래스의 역할이 커지고 추후 기능 추가 요구 사항에 대비하여 기존 TestShell 클래스의 일부 기능을 CommandParser 로 이관했습니다.
---
### 변경 내용
* TestShell 클래스의 일부 역할을 CommandParser 클래스로 이관
* TestShell.execute 메서드 정적 메서드로 변경
* CommandParser의 상수를 식별이 쉬운 이름으로 정리하기위한 get_command 메서드 추가
* command parsing에 필요한 데이터 통합(cmd_if_dict + cmd_option_to_args_dict)