### PR TITLE
[mod] command parse 부분 일부 변경

### DIFF
--- a/testapp/command_parser.py
+++ b/testapp/command_parser.py
@@ -84,7 +84,7 @@ class CommandParser:
             elif cmd_option == "fullwrite":
                 cmd_args[0] = int(cmd_args[0], 16)
             return cmd_option, cmd_args
-        return cmd_option, None
+        return cmd_option, []
 
     @classmethod
     def get_command(cls, cmd_option):

--- a/testapp/testshell.py
+++ b/testapp/testshell.py
@@ -15,16 +15,9 @@ class TestShell:
             return EXECUTE_INVALID
 
         cmd_option, cmd_args = CommandParser.parse_args(cmd)
-
         cmd_if = CommandParser.get_command(cmd_option)
-        if cmd_args is not None:
-            print(cmd_option, *cmd_args)
-            cmd_if.run(*cmd_args)
-            return EXECUTE_VALID_WITH_ARGS
-
-        print(cmd_option)
-        cmd_if.run()
-        return EXECUTE_VALID_WO_ARGS
+        cmd_if.run(*cmd_args)
+        return EXECUTE_VALID_WITH_ARGS if cmd_args else EXECUTE_VALID_WO_ARGS
 
 
 def main():

--- a/tests/testapp_test/test_command_parser.py
+++ b/tests/testapp_test/test_command_parser.py
@@ -109,9 +109,9 @@ class TestCommandParser(TestCase):
         cmd_dict = {
             "write 3 0xAAAABBBB": ("write", [3, 0xAAAABBBB]),
             "read 3": ("read", [3]),
-            "help": ("help", None),
+            "help": ("help", []),
             "fullwrite 0xABCDFFFF": ("fullwrite", [0xABCDFFFF]),
-            "fullread": ("fullread", None),
+            "fullread": ("fullread", []),
         }
         for idx, (key, val) in enumerate(cmd_dict.items()):
             with self.subTest(idx=idx, key=key, val=val):


### PR DESCRIPTION
argument가 필요없는 command의 경우 빈 리스트 return 하여 TestShell 클래스에서 동일한 형태로 사용할 수 있도록 변경
#34 