### PR TITLE
[mod] command arguments 전달할 때 중복되는 동작 제거

### DIFF
--- a/testapp/command_parser.py
+++ b/testapp/command_parser.py
@@ -1,5 +1,5 @@
 import re
-from typing import Tuple, Optional, List
+from typing import Any
 
 from testapp import command
 from testapp.constants import SSD_START_LBA, SSD_END_LBA, SSD_MIN_VALUE, SSD_MAX_VALUE
@@ -71,20 +71,10 @@ class CommandParser:
         return True
 
     @staticmethod
-    def parse_args(cmd: str) -> Tuple[str, Optional[List[int]]]:
+    def parse_args(cmd: str) -> tuple[str, list[str]] | tuple[str, list[Any]]:
         cmd_list = cmd.split(" ")
         cmd_option = cmd_list[0]
-        if len(cmd_list) > 1:
-            cmd_args: list = cmd_list[1:]
-            if cmd_option == "read":
-                cmd_args[0] = int(cmd_args[0])
-            elif cmd_option == "write":
-                cmd_args[0] = int(cmd_args[0])
-                cmd_args[1] = int(cmd_args[1], 16)
-            elif cmd_option == "fullwrite":
-                cmd_args[0] = int(cmd_args[0], 16)
-            return cmd_option, cmd_args
-        return cmd_option, []
+        return (cmd_option, cmd_list[1:]) if len(cmd_list) > 1 else (cmd_option, [])
 
     @classmethod
     def get_command(cls, cmd_option):

--- a/testapp/ssd_driver.py
+++ b/testapp/ssd_driver.py
@@ -24,9 +24,9 @@ class SsdDriver:
         except subprocess.CalledProcessError as e:
             raise Exception(f"Error executing command: {e.stderr}")
 
-    def read(self, lba: int) -> int:
+    def read(self, lba: str) -> str:
         self.run_subprocess(f"ssd R {lba}")
         return get_ssd_result()
 
-    def write(self, lba: int, value: int):
-        self.run_subprocess(f"ssd W {lba} 0x{value:08X}")
+    def write(self, lba: str, value: str):
+        self.run_subprocess(f"ssd W {lba} {value}")

--- a/testapp/ssd_driver.py
+++ b/testapp/ssd_driver.py
@@ -1,4 +1,5 @@
 import subprocess
+
 from testapp.util import get_ssd_result, validate_ssd_command, BASE_DIR
 
 
@@ -24,9 +25,9 @@ class SsdDriver:
         except subprocess.CalledProcessError as e:
             raise Exception(f"Error executing command: {e.stderr}")
 
-    def read(self, lba: str) -> str:
+    def read(self, lba: str | int) -> str:
         self.run_subprocess(f"ssd R {lba}")
         return get_ssd_result()
 
-    def write(self, lba: str, value: str):
+    def write(self, lba: str | int, value: str):
         self.run_subprocess(f"ssd W {lba} {value}")

--- a/tests/testapp_test/test_command_parser.py
+++ b/tests/testapp_test/test_command_parser.py
@@ -100,10 +100,10 @@ class TestCommandParser(TestCase):
 
     def test_parse_args(self):
         cmd_dict = {
-            "write 3 0xAAAABBBB": ("write", [3, 0xAAAABBBB]),
-            "read 3": ("read", [3]),
+            "write 3 0xAAAABBBB": ("write", ['3', '0xAAAABBBB']),
+            "read 3": ("read", ['3']),
             "help": ("help", []),
-            "fullwrite 0xABCDFFFF": ("fullwrite", [0xABCDFFFF]),
+            "fullwrite 0xABCDFFFF": ("fullwrite", ['0xABCDFFFF']),
             "fullread": ("fullread", []),
         }
         for idx, (key, val) in enumerate(cmd_dict.items()):

--- a/tests/testapp_test/test_ssd_driver.py
+++ b/tests/testapp_test/test_ssd_driver.py
@@ -46,8 +46,8 @@ class TestSsdDriver(unittest.TestCase):
 
     @patch('testapp.ssd_driver.SsdDriver.run_subprocess')
     def test_write(self, mock_run):
-        test_lba = 3
-        test_value = 0x1289CDEF
-        expected_command = f"ssd W {test_lba} 0x{test_value:08X}"
+        test_lba = "3"
+        test_value = "0x1289CDEF"
+        expected_command = f"ssd W {test_lba} {test_value}"
         self.driver.write(test_lba, test_value)
         mock_run.assert_called_once_with(expected_command)

--- a/tests/testapp_test/test_testshell.py
+++ b/tests/testapp_test/test_testshell.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from testapp.command import Read, Write, FullRead, FullWrite
+from testapp.ssd_driver import SsdDriver
 from testapp.test_app1 import TestApp1
 from testapp.test_app2 import TestApp2
 from testapp.testshell import TestShell, EXECUTE_INVALID, EXECUTE_VALID_WO_ARGS, EXECUTE_VALID_WITH_ARGS
@@ -47,3 +48,13 @@ class TestTestShell(TestCase):
         ret = self.ts.execute(cmd)
 
         self.assertEqual(ret, EXECUTE_INVALID)
+
+    @patch.object(SsdDriver, "run_subprocess")
+    def test_execute_read_command(self, mock_read):
+        self.ts.execute("read 3")
+        mock_read.assert_called_with("ssd R 3")
+
+    @patch.object(SsdDriver, "run_subprocess")
+    def test_execute_write_command(self, mock_write):
+        self.ts.execute("write 3 0xAAAABBBB")
+        mock_write.assert_called_with("ssd W 3 0xAAAABBBB")


### PR DESCRIPTION
ssd 프로세스에 전달할 명령어 생성 시 str 타입으로 전환하는 부분에서 불필요한 동작 발견
* str -> int -> str

해당 동작 제거하여 코드 가독성 확보