### PR TITLE
logger쪽 hotfix

### DIFF
--- a/my_logger/util_log.py
+++ b/my_logger/util_log.py
@@ -1,8 +1,8 @@
 import logging
 import os
 from datetime import datetime
-from logging.handlers import RotatingFileHandler
 from pathlib import Path
+from concurrent_log_handler import ConcurrentRotatingFileHandler
 import inspect
 import re
 
@@ -28,7 +28,7 @@ def print_function_name(func):
     return wrapper
 
 
-class MyRotatingFileHandler(RotatingFileHandler):
+class MyRotatingFileHandler(ConcurrentRotatingFileHandler):
     """
     로그 파일이 회전될 때 파일 이름을 변경하는 기능을 추가한 RotatingFileHandler 클래스입니다.
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pylint
 sphinx
 sphinx-autoapi
 sphinx-rtd-theme
+concurrent-log-handler

--- a/testapp/scripts/_script_manager.py
+++ b/testapp/scripts/_script_manager.py
@@ -93,7 +93,7 @@ def run_script(script_name: str, use_print: bool = False) -> bool:
                 Logger().info(result.stdout)
             else:
                 Logger().debug(result.stdout)
-        if result.stderr:
+        elif result.stderr:
             Logger().debug(result.stderr)
         return result.returncode == 0
     except Exception as e:


### PR DESCRIPTION
1. 여러 process가 logger 사용하더라도 문제 없도록 log handle 변경
2. subprocess.run의 stdout / stderr가 같은 값을 가지고 있어 결과가 두번 출력되는 문제 해결