### PR TITLE
Hotfix/fullread log

### DIFF
--- a/my_logger/util_log.py
+++ b/my_logger/util_log.py
@@ -1,8 +1,8 @@
 import logging
 import os
 from datetime import datetime
-from logging.handlers import RotatingFileHandler
 from pathlib import Path
+from concurrent_log_handler import ConcurrentRotatingFileHandler
 import inspect
 import re
 
@@ -28,7 +28,7 @@ def print_function_name(func):
     return wrapper
 
 
-class MyRotatingFileHandler(RotatingFileHandler):
+class MyRotatingFileHandler(ConcurrentRotatingFileHandler):
     """
     로그 파일이 회전될 때 파일 이름을 변경하는 기능을 추가한 RotatingFileHandler 클래스입니다.
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pylint
 sphinx
 sphinx-autoapi
 sphinx-rtd-theme
+concurrent-log-handler

--- a/ssd/__main__.py
+++ b/ssd/__main__.py
@@ -20,8 +20,12 @@ class SSDRunner:
     """
 
     def __init__(self):
+        Logger().debug("[SSD] Start SSDRunner")
         self.ssd = SolidStateDrive()
         self.option_buf = CommandBuffer()
+
+    def __del__(self):
+        Logger().debug("[SSD] Finish SSDRunner")
 
     def buff_flush(self):
         """
@@ -36,6 +40,8 @@ class SSDRunner:
         """
         주어진 명령어를 파싱하고 실행합니다.
         """
+        Logger().debug(f"[SSD] Received CMD : {cmd.get_value()}")
+
         if cmd.option == 'F':
             self.buff_flush()
         elif cmd.option == 'R':
@@ -70,9 +76,5 @@ class SSDRunner:
 
 
 if __name__ == '__main__':
-    Logger().debug("[SSD] Start SSDRunner")
-    runner = SSDRunner()
     cmd_ = CommandFactory.parse_command(sys.argv[1:])
-    Logger().debug(f"[SSD] Received CMD : {cmd_.get_value()}")
-    runner.run(cmd_)
-    Logger().debug("[SSD] Finish SSDRunner")
+    SSDRunner().run(cmd_)

--- a/testapp/scripts/_script_manager.py
+++ b/testapp/scripts/_script_manager.py
@@ -93,7 +93,7 @@ def run_script(script_name: str, use_print: bool = False) -> bool:
                 Logger().info(result.stdout)
             else:
                 Logger().debug(result.stdout)
-        if result.stderr:
+        elif result.stderr:
             Logger().debug(result.stderr)
         return result.returncode == 0
     except Exception as e:


### PR DESCRIPTION
1.여러 process가 logger 사용하더라도 문제 없도록 log handle 변경
2.subprocess.run의 stdout / stderr가 같은 값을 가지고 있어 결과가 두번 출력되는 문제 해결
3.requirement.txt에 필요한 package 추가
4.SSDRunner main 수행 시 class/func명 없어서 로그에 module()로 표시되는 문제 해결을 위해 class내부로 로깅위치 변경 